### PR TITLE
Added GTK version 4.12.4 to the Docker container build process.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,9 @@ jobs:
           - name: gtk-4.10
             gtktag: 4.10.0
             adwtag: 1.3.2
+          - name: gtk-4.12
+            gtktag: 4.12.4
+            adwtag: 1.3.6
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Closes #29.

The newer version of Adwaita doesn't yet build, as the newest version of `appstream` in Fedora's repos is `1.0.1`, but the build process expects `>= 1.0.2`.