### PR TITLE
Added explanation for archiving now that zip isn't present in the package script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,18 @@ If your Docker host uses SELinux and you're getting errors about Cargo.toml not 
 docker run -ti -v `pwd`:/mnt:z gtk4-cross-rust
 ```
 
-Then run `build` to build the project and `package` to package it into a zip file.
+Then run `build` to build the project and `package` to package it into a directory with all needed dependencies.
 
+### Archiving the executables
+
+To create an archive from the directory, you could run the following commands:
+
+```bash
+dnf install -y zip 
+zip -qr package.zip package/*
+rm -rf package
+```
+  
 `package.zip` will be present in your project directory.
 
 ## Image building

--- a/gtk4-cross-base-hub/Dockerfile
+++ b/gtk4-cross-base-hub/Dockerfile
@@ -20,7 +20,7 @@ RUN . ~/.cargo/env && cargo install --git https://github.com/MGlolenstine/peldd_
 FROM fedora:40
 COPY --from=0 /root/pe-util/build/peldd /usr/bin/peldd
 COPY --from=1 /root/.cargo/bin/peldd_dependency_scanner /usr/bin/pds
-RUN dnf install git mingw64-binutils mingw64-gcc meson mingw64-pango mingw64-gdk-pixbuf mingw64-libepoxy mingw64-winpthreads-static glib2-devel gobject-introspection-devel mingw64-gstreamer1-plugins-bad-free vala wine cmake gcc zip boost boost-system dos2unix sassc mingw64-librsvg2 intltool itstool gtk-update-icon-cache adwaita-icon-theme mingw64-adwaita-icon-theme mingw64-gettext mingw64-libyaml mingw64-xz mingw64-xz-libs mingw64-zstd gperf -y && dnf clean all -y
+RUN dnf install git mingw64-binutils mingw64-gcc meson mingw64-pango mingw64-gdk-pixbuf mingw64-libepoxy mingw64-winpthreads-static glib2-devel gobject-introspection-devel mingw64-gstreamer1-plugins-bad-free vala wine cmake gcc boost boost-system dos2unix sassc mingw64-librsvg2 intltool itstool gtk-update-icon-cache adwaita-icon-theme mingw64-adwaita-icon-theme mingw64-gettext mingw64-libyaml mingw64-xz mingw64-xz-libs mingw64-zstd gperf -y && dnf clean all -y
 
 # Clone the gtk4 repository (Move after the mingw setup for efficiency later)
 WORKDIR /tmp


### PR DESCRIPTION
Added a suggestion on how to package the executables now that there's no automatic archiving inside of `package.sh`.

Closes #32 .