### PR TITLE
Add support for gtk-4.21 and adwaita-1.8

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,18 +17,9 @@ jobs:
           - name: gtk-nightly
             gtktag: main
             adwtag: main
-          - name: gtk-4.6
-            gtktag: 4.6.3
-            adwtag: 1.1.1
-          - name: gtk-4.8
-            gtktag: 4.8.2
-            adwtag: 1.2.0
-          - name: gtk-4.10
-            gtktag: 4.10.0
-            adwtag: 1.3.2
-          - name: gtk-4.12
-            gtktag: 4.12.4
-            adwtag: 1.3.6
+          - name: gtk-4.21
+            gtktag: 4.21.0
+            adwtag: 1.8.1
       fail-fast: false
 
     steps:
@@ -69,7 +60,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-        
       - name: Extract metadata (tags, labels) for Docker
         id: meta_rust
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38

--- a/build_image.sh
+++ b/build_image.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 GTK=${GTK:-"main"}
 ADW=${ADW:-"main"}
-BASE=${BASE:-"gtk4-cross-base-$GTK-$ADW"}
+BASE=${BASE:-"gtk4-cross-base-hub-$GTK-$ADW"}
 
 if [[ $1 == "base" ]]; then
     echo "Building base image"

--- a/gtk4-cross-base-hub/Dockerfile
+++ b/gtk4-cross-base-hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:42
 WORKDIR /root
 RUN dnf install -y git cmake gcc-c++ boost-devel
 RUN git clone https://github.com/gsauthof/pe-util
@@ -9,15 +9,15 @@ WORKDIR /root/pe-util/build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release
 RUN make
 
-FROM fedora:40
+FROM fedora:42
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-# RUN . ~/.cargo/env 
+# RUN . ~/.cargo/env
 # Set the rust linker to gcc
 # RUN echo "[target.x86_64-pc-windows-gnu]\nlinker = \"x86_64-w64-mingw32-gcc\"\nar = \"x86_64-w64-mingw32-gcc-ar\"" > /home/rust/.cargo/config
 RUN dnf install -y gcc
 RUN . ~/.cargo/env && cargo install --git https://github.com/MGlolenstine/peldd_dependency_scanner.git
 
-FROM fedora:40
+FROM fedora:42
 COPY --from=0 /root/pe-util/build/peldd /usr/bin/peldd
 COPY --from=1 /root/.cargo/bin/peldd_dependency_scanner /usr/bin/pds
 RUN dnf install git mingw64-binutils mingw64-gcc meson mingw64-pango mingw64-gdk-pixbuf mingw64-libepoxy mingw64-winpthreads-static glib2-devel gobject-introspection-devel mingw64-gstreamer1-plugins-bad-free vala wine cmake gcc zip boost boost-system dos2unix sassc mingw64-librsvg2 intltool itstool gtk-update-icon-cache adwaita-icon-theme mingw64-adwaita-icon-theme mingw64-gettext mingw64-libyaml mingw64-xz mingw64-xz-libs mingw64-zstd gperf -y && dnf clean all -y

--- a/gtk4-cross-base-hub/Dockerfile
+++ b/gtk4-cross-base-hub/Dockerfile
@@ -20,7 +20,8 @@ RUN . ~/.cargo/env && cargo install --git https://github.com/MGlolenstine/peldd_
 FROM fedora:42
 COPY --from=0 /root/pe-util/build/peldd /usr/bin/peldd
 COPY --from=1 /root/.cargo/bin/peldd_dependency_scanner /usr/bin/pds
-RUN dnf install git mingw64-binutils mingw64-gcc meson mingw64-pango mingw64-gdk-pixbuf mingw64-libepoxy mingw64-winpthreads-static glib2-devel gobject-introspection-devel mingw64-gstreamer1-plugins-bad-free vala wine cmake gcc zip boost boost-system dos2unix sassc mingw64-librsvg2 intltool itstool gtk-update-icon-cache adwaita-icon-theme mingw64-adwaita-icon-theme mingw64-gettext mingw64-libyaml mingw64-xz mingw64-xz-libs mingw64-zstd gperf -y && dnf clean all -y
+# Some of these dependencies are likely not needed anymore
+RUN dnf install git mingw64-binutils mingw64-gcc meson mingw64-pango mingw64-gdk-pixbuf mingw64-libepoxy mingw64-winpthreads-static glib2-devel gobject-introspection-devel mingw64-gstreamer1-plugins-bad-free vala wine cmake gcc zip boost boost-system dos2unix sassc mingw64-librsvg2 intltool itstool gtk-update-icon-cache adwaita-icon-theme mingw64-adwaita-icon-theme mingw64-gettext mingw64-libyaml mingw64-xz mingw64-xz-libs mingw64-zstd gperf fedora-repos-rawhide mingw64-vulkan-loader mingw64-vulkan-headers glslc mingw64-gcc-c++ -y && dnf install --disablerepo="*" --enablerepo=rawhide mingw64-appstream -y && dnf clean all -y
 
 # Clone the gtk4 repository (Move after the mingw setup for efficiency later)
 WORKDIR /tmp
@@ -72,7 +73,7 @@ RUN wine $MINGW_PREFIX/bin/gdk-pixbuf-query-loaders.exe --update-cache
 
 # Build and install GTK4
 WORKDIR /tmp/gtk
-RUN x86_64-meson build -Dintrospection=disabled --wrap-mode=default
+RUN x86_64-meson build -Dintrospection=disabled -Dmedia-gstreamer=disabled --wrap-mode=default
 WORKDIR /tmp/gtk/build
 RUN meson configure -Db_lto=false -Dc_link_args="['-lssp']" -Dc_args=-DG_ENABLE_DEBUG -Dtracker=disabled
 RUN ninja all && ninja install


### PR DESCRIPTION
I had to disable gstreamer because the `mingw64-gstreamer1-plugins-bad-free` package that should contain it didn't provide the d3d12 plugin which it needed.
Apart from that, however, it seems to work!
Closes #36 